### PR TITLE
Target es2019

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,5 +1,6 @@
 {
   "jsc": {
+    "target": "es2019",
     "parser": {
       "classProperty": true,
       "jsx": true,


### PR DESCRIPTION
Targets es2019 (removes the need of a runtime for `async`).